### PR TITLE
Deploy latest development changes

### DIFF
--- a/.github/workflows/adjust-data-folder-prototype.sh
+++ b/.github/workflows/adjust-data-folder-prototype.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# -
+# Script to adjust the data folder when deploying inside the Laravel prototype
+#
+# The data folder is changed to a symlink pointing to the Laravel storage
+# folder, so that we don't have to change all the path in the legacy site
+set -e
+
+DEPLOY_USER=$1
+DEPLOY_HOST=$2
+DEPLOY_PATH=$3
+
+if [ -z "$DEPLOY_USER" ] || [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_PATH" ]; then
+    echo "Missing mandatory deployment arguments"
+    exit
+fi
+
+mkdir -p ~/.ssh/
+ssh-keyscan $DEPLOY_HOST >> ~/.ssh/known_hosts
+
+ssh $DEPLOY_USER@$DEPLOY_HOST "cd $DEPLOY_PATH/ && test -h data || ln -s ../storage data"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -61,6 +61,24 @@ jobs:
           ssh-add - <<< "${{ secrets.DEPLOY_SSH_KEY }}"
           ./.github/workflows/deploy.sh "${{ secrets.DEV_DEPLOY_USER }}" "${{ secrets.DEV_DEPLOY_HOST }}" "${{ secrets.DEV_DEPLOY_PATH }}"
 
+  deploy-prototype:
+    name: Deploy inside the Laravel prototype
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/development'
+    steps:
+      - uses: actions/checkout@v2
+      # Restore generated files from previous step
+      - uses: actions/download-artifact@v2
+        with:
+          name: website
+          path: public/
+      - name: Deploy
+        run: |
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< "${{ secrets.DEPLOY_SSH_KEY }}"
+          ./.github/workflows/deploy.sh "${{ secrets.DEV_DEPLOY_PROTOTYPE_USER }}" "${{ secrets.DEV_DEPLOY_PROTOTYPE_HOST }}" "${{ secrets.DEV_DEPLOY_PROTOTYPE_PATH }}"
+
   deploy-prod:
     name: Deploy production
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -73,6 +73,10 @@ jobs:
         with:
           name: website
           path: public/
+      - name: Adjust .htaccess files to run inside the prototype folder
+        run: |
+          mv -f public/.htaccess.prototype public/.htaccess
+          rm -f public/php/.htaccess
       - name: Deploy
         run: |
           eval "$(ssh-agent -s)"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -82,6 +82,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${{ secrets.DEPLOY_SSH_KEY }}"
           ./.github/workflows/deploy.sh "${{ secrets.DEV_DEPLOY_PROTOTYPE_USER }}" "${{ secrets.DEV_DEPLOY_PROTOTYPE_HOST }}" "${{ secrets.DEV_DEPLOY_PROTOTYPE_PATH }}"
+          ./.github/workflows/adjust-data-folder-prototype.sh "${{ secrets.DEV_DEPLOY_PROTOTYPE_USER }}" "${{ secrets.DEV_DEPLOY_PROTOTYPE_HOST }}" "${{ secrets.DEV_DEPLOY_PROTOTYPE_PATH }}"
 
   deploy-prod:
     name: Deploy production

--- a/public/.htaccess.prototype
+++ b/public/.htaccess.prototype
@@ -1,0 +1,53 @@
+Options +FollowSymlinks -MultiViews -Indexes
+
+# Custom error pages
+ErrorDocument 403 /themes/templates/1/forbidden.html
+ErrorDocument 404 /themes/templates/1/page_not_found.html
+
+# Configure compression on static resources
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/plain
+    AddOutputFilterByType DEFLATE text/html
+    AddOutputFilterByType DEFLATE text/xml
+    AddOutputFilterByType DEFLATE text/css
+    AddOutputFilterByType DEFLATE application/xml
+    AddOutputFilterByType DEFLATE application/xhtml+xml
+    AddOutputFilterByType DEFLATE application/rss+xml
+    AddOutputFilterByType DEFLATE application/javascript
+    AddOutputFilterByType DEFLATE application/x-javascript
+</IfModule>
+
+RewriteEngine On
+RewriteBase /
+
+# Send all traffic to HTTPS, except when serving on localhost for development
+RewriteCond "%{HTTPS}" "off"
+RewriteCond "%{SERVER_NAME}" (www\.)?atarilegend\.com
+RewriteRule (.*) https://%{SERVER_NAME}/$1 [R=301,L]
+
+# Rewrite old interviews URLs to the new structure, as multiple websites are
+# still linking to the old URLs. e.g.:
+# /interviews/interview.php?interview_id=4 -> /interviews/interviews_detail.php?selected_interview_id=4
+RewriteCond %{QUERY_STRING} "interview_id=([0-9]+)"
+RewriteRule "^interviews/interview\.php" "interviews/interviews_detail.php?selected_interview_id=%1" [R=301,L]
+
+# The following rules are to hide the root level /php/ and /php/main/
+# folders from the URL. We want to simulate users accessing files under these
+# folders as if they were are the root / of the website.
+# This is needed to maintain the links other websites (like Lemon Amiga) made
+# to /games/games_details.php?game_id=...
+
+# If request are coming for /php/something.php, redirect them to /something.php
+# Use 307 and not 301 to cover POST redirection (See issue #250)
+RewriteCond %{THE_REQUEST} ^[A-Z]{3,}\s+/legacy/php/([^\s]+) [NC]
+RewriteRule ^ /legacy/%1 [R=307,L]
+
+# If the requested folder or file doesn't exist, look it up under php/
+# For example if the request is /main/front/front.php, look it up
+# at php/main/front/front.php
+# __Note__  It works with conjunction with php/.htaccess, so that requests
+# to /front/front.php gets rewritten to main/front/front.php first, then
+# front/front.php by php/.htaccess
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule (?!^php/)^(.*)$ /legacy/php/$1 [L,NC]

--- a/public/php/lib/functions.php
+++ b/public/php/lib/functions.php
@@ -84,6 +84,42 @@ function InsertALCode($alcode) {
         $alcode
     );
 
+    $alcode = preg_replace(
+        "@\[game=([0-9]+)\](.*?)\[/game\]@i",
+        "<a href=\"/games/games_detail.php?game_id=$1\" class=\"standard_tile_link_black\">$2</a>",
+        $alcode
+    );
+
+    $alcode = preg_replace(
+        "@\[review=([0-9]+)\](.*?)\[/review\]@i",
+        "<a href=\"/games/games_reviews_detail.php?review_id=$1\" class=\"standard_tile_link_black\">$2</a>",
+        $alcode
+    );
+
+    $alcode = preg_replace(
+        "@\[interview=([0-9]+)\](.*?)\[/interview\]@i",
+        "<a href=\"/interviews/interviews_detail.php?selected_interview_id=$1\" class=\"standard_tile_link_black\">$2</a>",
+        $alcode
+    );
+
+    $alcode = preg_replace(
+        "@\[article=([0-9]+)\](.*?)\[/article\]@i",
+        "<a href=\"/articles/articles_detail.php?selected_article_id=$1\" class=\"standard_tile_link_black\">$2</a>",
+        $alcode
+    );
+
+    $alcode = preg_replace(
+        "@\[company=([0-9]+)\](.*?)\[/company\]@i",
+        "<a href=\"/games/games_main_list.php?developer=$1&action=search\" class=\"standard_tile_link_black\">$2</a>",
+        $alcode
+    );
+
+    $alcode = preg_replace(
+        "@\[releaseYear=([0-9]+)\](.*?)\[/releaseYear\]@i",
+        "<a href=\"/games/games_main_list.php?year_input=$1&action=search\" class=\"standard_tile_link_black\">$2</a>",
+        $alcode
+    );
+
     return $alcode;
 }
 
@@ -1750,7 +1786,7 @@ function create_log_entry($section, $section_id, $subsection, $subsection_id, $a
             $subsection_name = $query_data['pub_dev_name'];
             $subsection_id = $query_data['game_release_id'];
         }
-        
+
         if ($subsection == 'Crew') {
             // get the distributor name
             $query_crew = "SELECT * FROM crew

--- a/public/php/lib/functions.php
+++ b/public/php/lib/functions.php
@@ -98,7 +98,8 @@ function InsertALCode($alcode) {
 
     $alcode = preg_replace(
         "@\[interview=([0-9]+)\](.*?)\[/interview\]@i",
-        "<a href=\"/interviews/interviews_detail.php?selected_interview_id=$1\" class=\"standard_tile_link_black\">$2</a>",
+        "<a href=\"/interviews/interviews_detail.php?selected_interview_id=$1\""
+            ." class=\"standard_tile_link_black\">$2</a>",
         $alcode
     );
 

--- a/public/php/main/games/games_detail.php
+++ b/public/php/main/games/games_detail.php
@@ -103,7 +103,7 @@ function generate_game_description(
     $desc .= "game for the Atari ST ";
 
     if ($game_developers) {
-        $desc .= "developed by ".join($game_developers, ", ")." ";
+        $desc .= "developed by ".join(", ", $game_developers)." ";
     }
 
     if ($game_releases) {
@@ -122,7 +122,7 @@ function generate_game_description(
             }
         }
         if ($years) {
-            $desc .= "released in ".join($years, ", ");
+            $desc .= "released in ".join(", ", $years);
         }
     }
 
@@ -155,13 +155,13 @@ function generate_game_description(
     }
 
     if ($extra_info) {
-        $desc .= " (".join($extra_info, ", ").")";
+        $desc .= " (".join(", ", $extra_info).")";
     }
 
     $desc .= ".";
 
     if (count($game_akas) > 0) {
-        $desc .= " It's also known as: ".join($game_akas, ", ").".";
+        $desc .= " It's also known as: ".join(", ", $game_akas).".";
     }
 
     return $desc;

--- a/public/themes/templates/1/admin/articles/articles_edit.html
+++ b/public/themes/templates/1/admin/articles/articles_edit.html
@@ -131,6 +131,13 @@
                         <input type="button" class="secondary_button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'textintro')">
                         <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textintro')">
                         <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textintro')">
+
                         <textarea name="textintro" rows="5" class="primary_textarea" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);" required>{$article.article_intro}</textarea>
                         <br>
                         <br>
@@ -141,6 +148,13 @@
                         <input type="button" class="secondary_button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'textfield')">
                         <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield')">
                         <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield')"/>
+                        <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textfield')">
+
                         <textarea name="textfield" rows="25" class="primary_textarea" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);" required>{$article.article_text}</textarea>
                     </fieldset>
                     <br>

--- a/public/themes/templates/1/admin/company/company_edit.html
+++ b/public/themes/templates/1/admin/company/company_edit.html
@@ -21,6 +21,7 @@ The company edit page
 
 {block name=java_script}
 <script src="../templates/0/js/game_comment.js"></script>
+<script src="{$template_dir}includes/js/bbcode.js"></script><!-- Load the BBCODE script -->
 <script>
 $(function() {
     $but = $('#file_upload_user_detail');
@@ -68,136 +69,6 @@ function companydelete(comp_id) {
         }
     });
 }
-
-var clientPC = navigator.userAgent.toLowerCase(); // Get client info
-var clientVer = parseInt(navigator.appVersion); // Get browser version
-
-var is_ie = ((clientPC.indexOf("msie") != -1) && (clientPC.indexOf("opera") == -1));
-var is_nav = ((clientPC.indexOf('mozilla')!=-1) && (clientPC.indexOf('spoofer')==-1)
-                && (clientPC.indexOf('compatible') == -1) && (clientPC.indexOf('opera')==-1)
-                && (clientPC.indexOf('webtv')==-1) && (clientPC.indexOf('hotjava')==-1));
-var is_moz = 0;
-
-var is_win = ((clientPC.indexOf("win")!=-1) || (clientPC.indexOf("16bit") != -1));
-var is_mac = (clientPC.indexOf("mac")!=-1);
-
-// Helpline messages
-b_help = "Bold text: [b]text[/b]  (alt+b)";
-i_help = "Italic text: [i]text[/i]  (alt+i)";
-u_help = "Underline text: [u]text[/u]  (alt+u)";
-q_help = "Quote text: [quote]text[/quote]  (alt+q)";
-h_help = "Insert URL: [url]http://url[/url] or [url=http://url]URL text[/url]";
-e_help = "Insert email: [@]email address[/@] or [@=email]email text[/@]";
-s_help = "Insert Hotspot Source: [hotspotUrl=#]";
-t_help = "Insert Hotspot Target: [hotspot=#]";
-x_help = "Set Smiley";
-
-// Define the bbCode tags
-bbtags = new Array('[b]','[/b]','[i]','[/i]','[u]','[/u]','[url]','[/url]','[mail]','[/mail]', '[hotspotUrl=#]', '[/hotspotUrl]', '[hotspot=]', '[/hotspot]');
-bbcode = new Array();
-imageTag = false;
-
-// Shows the help messages in the helpline window
-function helpline(help) {
-    document.post.helpbox.value = eval(help + "_help");
-}
-
-function bbstyle(bbnumber, bbname) {
-
-    var txtarea = eval('document.post.' + bbname);
-
-    txtarea.focus();
-    donotinsert = false;
-    theSelection = false;
-    bblast = 0;
-
-    if (bbnumber == -1) { // Close all open tags & default button names
-        while (bbcode[0]) {
-            butnumber = arraypop(bbcode) - 1;
-            txtarea.value += bbtags[butnumber + 1];
-            buttext = eval('document.post.addbbcode' + butnumber + '.value');
-            eval('document.post.addbbcode' + butnumber + '.value ="' + buttext.substr(0,(buttext.length - 1)) + '"');
-        }
-        imageTag = false; // All tags are closed including image tags :D
-        txtarea.focus();
-        return;
-    }
-
-    if ((clientVer >= 4) && is_ie && is_win)
-    {
-        theSelection = document.selection.createRange().text; // Get text selection
-        if (theSelection) {
-            // Add tags around selection
-            document.selection.createRange().text = bbtags[bbnumber] + theSelection + bbtags[bbnumber+1];
-            txtarea.focus();
-            theSelection = '';
-            return;
-        }
-    }
-    else if (txtarea.selectionEnd && (txtarea.selectionEnd - txtarea.selectionStart > 0))
-    {
-        mozWrap(txtarea, bbtags[bbnumber], bbtags[bbnumber+1]);
-        return;
-    }
-
-    // Find last occurance of an open tag the same as the one just clicked
-    for (i = 0; i < bbcode.length; i++) {
-        if (bbcode[i] == bbnumber+1) {
-            bblast = i;
-            donotinsert = true;
-        }
-    }
-
-    if (donotinsert) {      // Close all open tags up to the one just clicked & default button names
-        while (bbcode[bblast]) {
-                butnumber = arraypop(bbcode) - 1;
-                txtarea.value += bbtags[butnumber + 1];
-                buttext = eval('document.post.addbbcode' + butnumber + '.value');
-                eval('document.post.addbbcode' + butnumber + '.value ="' + buttext.substr(0,(buttext.length - 1)) + '"');
-                imageTag = false;
-            }
-            txtarea.focus();
-            return;
-    } else { // Open tags
-
-        if (imageTag && (bbnumber != 14)) {     // Close image tag before adding another
-            txtarea.value += bbtags[15];
-            lastValue = arraypop(bbcode) - 1;   // Remove the close image tag from the list
-            document.post.addbbcode14.value = "Img";    // Return button back to normal state
-            imageTag = false;
-        }
-
-        // Open tag
-        txtarea.value += bbtags[bbnumber];
-        if ((bbnumber == 14) && (imageTag == false)) imageTag = 1; // Check to stop additional tags after an unclosed image tag
-        arraypush(bbcode,bbnumber+1);
-        eval('document.post.addbbcode'+bbnumber+'.value += "*"');
-        txtarea.focus();
-        return;
-    }
-    storeCaret(txtarea);
-}
-
-// From http://www.massless.org/mozedit/
-function mozWrap(txtarea, open, close) {
-    var selLength = txtarea.textLength;
-    var selStart = txtarea.selectionStart;
-    var selEnd = txtarea.selectionEnd;
-    if (selEnd == 1 || selEnd == 2)
-        selEnd = selLength;
-
-    var s1 = (txtarea.value).substring(0,selStart);
-    var s2 = (txtarea.value).substring(selStart, selEnd)
-    var s3 = (txtarea.value).substring(selEnd, selLength);
-    txtarea.value = s1 + open + s2 + close + s3;
-    return;
-}
-
-// Insert at Claret position. Code from
-// http://www.faqts.com/knowledge_base/view.phtml/aid/1052/fid/130
-function storeCaret(textEl) {
-    if (textEl.createTextRange) textEl.caretPos = document.selection.createRange().duplicate();
-}
 </script>
 {/block}
 
@@ -231,6 +102,12 @@ function storeCaret(textEl) {
                 <input type="button" class="secondary_button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'textfield')">
                 <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield')">
                 <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textfield')">
                 <textarea name="textfield" rows="15" class="primary_textarea" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$company.comp_profile}</textarea>
                 <br>
                 <br>

--- a/public/themes/templates/1/admin/games/games_facts.html
+++ b/public/themes/templates/1/admin/games/games_facts.html
@@ -48,6 +48,12 @@
                 <input type="button" class="secondary_button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'fact_text')">
                 <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'fact_text')">
                 <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'fact_text')"/>
+                <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'fact_text')">
+                <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'fact_text')">
+                <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'fact_text')">
+                <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'fact_text')">
+                <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'fact_text')">
+                <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'fact_text')">
                 <textarea name="fact_text" id="fact_text" class="primary_textarea" rows="4" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);" required></textarea>
                 <br><br>
                 <label for="file_upload2" class="secondary_button">Select file(s)</label>

--- a/public/themes/templates/1/admin/games/games_review_edit.html
+++ b/public/themes/templates/1/admin/games/games_review_edit.html
@@ -105,8 +105,14 @@
                     <input type="button" class="secondary_button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'textfield')">
                     <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield')">
                     <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield')">
-                    <input type="button" class="secondary_button" accesskey="screenstar" name="addbbcode16" value="Screenstar" onClick="bbstyle(16,'textfield')">
-                    <input type="button" class="secondary_button" accesskey="frontpage" name="addbbcode14" value="Frontpage" onClick="bbstyle(14,'textfield')">
+                    <input type="button" class="secondary_button" name="addbbcode16" value="Screenstar" onClick="bbstyle(16,'textfield')">
+                    <input type="button" class="secondary_button" name="addbbcode14" value="Frontpage" onClick="bbstyle(14,'textfield')">
+                    <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textfield')">
+                    <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textfield')">
+                    <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textfield')">
+                    <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textfield')">
+                    <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textfield')">
+                    <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textfield')">
                     <textarea name="textfield" rows="15" class="primary_textarea" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$edit_review.review_text}</textarea>
                     <br>
                     <br>

--- a/public/themes/templates/1/admin/individuals/individuals_edit.html
+++ b/public/themes/templates/1/admin/individuals/individuals_edit.html
@@ -133,7 +133,13 @@ function nickdelete(nick_id,ind_id) {
                 <input type="button" class="secondary_button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'textfield')" onMouseOver="helpline('i')" />
                 <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield')" onMouseOver="helpline('h')" />
                 <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield')" onMouseOver="helpline('e')" />
-                <textarea name="textfield" rows="15" class="primary_textarea" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$individuals.ind_profile}</textarea>
+                <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textfield')">
+                <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textfield')">
+            <textarea name="textfield" rows="15" class="primary_textarea" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$individuals.ind_profile}</textarea>
                 <br>
                 <br>
                 <input type="submit" value="Update" class="secondary_button">

--- a/public/themes/templates/1/admin/interviews/interviews_edit.html
+++ b/public/themes/templates/1/admin/interviews/interviews_edit.html
@@ -146,6 +146,12 @@
                         <input type="button" class="secondary_button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'textintro')">
                         <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textintro')">
                         <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textintro')">
+                        <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textintro')">
                         <textarea name="textintro" rows="15" class="primary_textarea" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$interview.interview_intro}</textarea>
                         <br>
                         <br>
@@ -157,6 +163,12 @@
                         <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textchapters')">
                         <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textchapters')">
                         <input type="button" class="secondary_button" accesskey= "s" name="addbbcode10" value="Hotspot Source" onclick="bbstyle(10,'textchapters')"/>
+                        <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textchapters')">
+                        <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textchapters')">
+                        <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textchapters')">
+                        <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textchapters')">
+                        <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textchapters')">
+                        <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textchapters')">
                         <textarea name="textchapters" rows="15" class="primary_textarea" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$interview.interview_chapters}</textarea>
                         <br>
                         <br>
@@ -168,6 +180,12 @@
                         <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield')">
                         <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield')"/>
                         <input type="button" class="secondary_button" accesskey= "t" name="addbbcode12" value="Hotspot Target" onclick="bbstyle(12,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textfield')">
+                        <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textfield')">
                         <textarea name="textfield" rows="25" class="primary_textarea" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$interview.interview_text}</textarea>
                     </fieldset>
                     <br>

--- a/public/themes/templates/1/admin/news/ajax_news_approve_edit.html
+++ b/public/themes/templates/1/admin/news/ajax_news_approve_edit.html
@@ -52,6 +52,12 @@
         <input type="button" class="primary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield{$news_id}')">
         <input type="button" class="primary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield{$news_id}')">
         <input type="button" class="primary_button" accesskey="frontpage" name="addbbcode14" value="Frontpage" onClick="bbstyle(14,'textfield{$news_id}')">
+        <input type="button" class="primary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textfield{$news_id}')">
+        <input type="button" class="primary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textfield{$news_id}')">
+        <input type="button" class="primary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textfield{$news_id}')">
+        <input type="button" class="primary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textfield{$news_id}')">
+        <input type="button" class="primary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textfield{$news_id}')">
+        <input type="button" class="primary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textfield{$news_id}')">
         <br>
         <textarea class="primary_textarea" rows="4" name="textfield{$news_id}" id="jsNewsText" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$line->getText()}</textarea>
     {/foreach}

--- a/public/themes/templates/1/admin/news/ajax_news_post_edit.html
+++ b/public/themes/templates/1/admin/news/ajax_news_post_edit.html
@@ -57,6 +57,12 @@
     <input type="button" class="primary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield{$news_id}')">
     <input type="button" class="primary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield{$news_id}')">
     <input type="button" class="primary_button" accesskey="frontpage" name="addbbcode14" value="Frontpage" onClick="bbstyle(14,'textfield{$news_id}')">
+    <input type="button" class="primary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textfield{$news_id}')">
+    <input type="button" class="primary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textfield{$news_id}')">
+    <input type="button" class="primary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textfield{$news_id}')">
+    <input type="button" class="primary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textfield{$news_id}')">
+    <input type="button" class="primary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textfield{$news_id}')">
+    <input type="button" class="primary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textfield{$news_id}')">
     <br>
     <textarea class="primary_textarea" rows="4" name="textfield{$news_id}" id="jsNewsText" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$article->getText()}</textarea>
 {/if}

--- a/public/themes/templates/1/admin/news/news_add.html
+++ b/public/themes/templates/1/admin/news/news_add.html
@@ -94,6 +94,12 @@
                         <input type="button" class="secondary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'descr')">
                         <input type="button" class="secondary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'descr')">
                         <input type="button" class="secondary_button" accesskey="frontpage" name="addbbcode14" value="Frontpage" onClick="bbstyle(14,'descr')">
+                        <input type="button" class="secondary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'descr')">
+                        <input type="button" class="secondary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'descr')">
+                        <input type="button" class="secondary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'descr')">
+                        <input type="button" class="secondary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'descr')">
+                        <input type="button" class="secondary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'descr')">
+                        <input type="button" class="secondary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'descr')">
                         <br>
                         <textarea class="primary_textarea" rows="15" name="descr" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);" required></textarea>
                     </div>

--- a/public/themes/templates/1/includes/js/bbcode.js
+++ b/public/themes/templates/1/includes/js/bbcode.js
@@ -27,7 +27,13 @@ var is_win = ((clientPC.indexOf('win') != -1) || (clientPC.indexOf('16bit') != -
 var is_mac = (clientPC.indexOf('mac') != -1);
 
 // Define the bbCode tags
-bbtags = new Array('[b]', '[/b]', '[i]', '[/i]', '[u]', '[/u]', '[url=http://www.yourlink.com]', '[/url]', '[email]', '[/email]', '[hotspotUrl=#]', '[/hotspotUrl]', '[hotspot=]', '[/hotspot]', '[frontpage]', '[/frontpage]', '[screenstar]', '[/screenstar]');
+bbtags = new Array(
+    '[b]', '[/b]', '[i]', '[/i]', '[u]', '[/u]', '[url=http://www.yourlink.com]',
+    '[/url]', '[email]', '[/email]', '[hotspotUrl=#]', '[/hotspotUrl]', '[hotspot=]',
+    '[/hotspot]', '[frontpage]', '[/frontpage]', '[screenstar]', '[/screenstar]',
+    '[game=1234]', '[/game]', '[review=1234]', '[/review]', '[interview=1234]',
+    '[/interview]', '[article=1234]', '[/article]', '[company=1234]', '[/company]',
+    '[releaseYear=1989]', '[/releaseYear]');
 bbcode = new Array();
 imageTag = false;
 
@@ -41,7 +47,7 @@ function bbstyle (bbnumber, bbname) {
 
     if (bbnumber == -1) { // Close all open tags & default button names
         while (bbcode[0]) {
-            butnumber = arraypop(bbcode) - 1;
+            butnumber = bbcode.pop() - 1;
             txtarea.value += bbtags[butnumber + 1];
             buttext = eval('document.post.addbbcode' + butnumber + '.value');
             eval('document.post.addbbcode' + butnumber + '.value ="' + buttext.substr(0, (buttext.length - 1)) + '"');
@@ -75,7 +81,7 @@ function bbstyle (bbnumber, bbname) {
 
     if (donotinsert) {		// Close all open tags up to the one just clicked & default button names
         while (bbcode[bblast]) {
-            butnumber = arraypop(bbcode) - 1;
+            butnumber = bbcode.pop() - 1;
             txtarea.value += bbtags[butnumber + 1];
             buttext = eval('document.post.addbbcode' + butnumber + '.value');
             eval('document.post.addbbcode' + butnumber + '.value ="' + buttext.substr(0, (buttext.length - 1)) + '"');
@@ -86,7 +92,7 @@ function bbstyle (bbnumber, bbname) {
     } else { // Open tags
         if (imageTag && (bbnumber != 14)) {		// Close image tag before adding another
             txtarea.value += bbtags[15];
-            lastValue = arraypop(bbcode) - 1;	// Remove the close image tag from the list
+            lastValue = bbcode.pop() - 1;	// Remove the close image tag from the list
             document.post.addbbcode14.value = 'Img';	// Return button back to normal state
             imageTag = false;
         }
@@ -94,7 +100,7 @@ function bbstyle (bbnumber, bbname) {
         // Open tag
         txtarea.value += bbtags[bbnumber];
         if ((bbnumber == 14) && (imageTag == false)) imageTag = 1; // Check to stop additional tags after an unclosed image tag
-        arraypush(bbcode, bbnumber + 1);
+        bbcode.push(bbnumber + 1);
         eval('document.post.addbbcode' + bbnumber + '.value += "*"');
         txtarea.focus();
         return;
@@ -157,6 +163,25 @@ function previewText (text) {
     }
     text = text.replaceAll('[/hotspotUrl]', '</a>');
     text = text.replaceAll('[/hotspot]', '</a>');
+
+    text = text.replace(/\[game=([0-9]+)\]/ig, '<a href="/games/games_detail.php?game_id=$1">');
+    text = text.replace(/\[\/game\]/ig, '</a>');
+
+    text = text.replace(/\[review=([0-9]+)\]/ig, '<a href="/games/games_reviews_detail.php?review_id=$1">');
+    text = text.replace(/\[\/review\]/ig, '</a>');
+
+    text = text.replace(/\[interview=([0-9]+)\]/ig, '<a href="/interviews/interviews_detail.php?selected_interview_id=$1">');
+    text = text.replace(/\[\/interview\]/ig, '</a>');
+
+    text = text.replace(/\[article=([0-9]+)\]/ig, '<a href="/articles/articles_detail.php?selected_article_id=$1">');
+    text = text.replace(/\[\/article\]/ig, '</a>');
+
+    text = text.replace(/\[company=([0-9]+)\]/ig, '<a href="/games/games_main_list.php?developer=$1&action=search">');
+    text = text.replace(/\[\/company\]/ig, '</a>');
+
+    text = text.replace(/\[releaseYear=([0-9]+)\]/ig, '<a href="/games/games_main_list.php?year_input=$1&action=search">');
+    text = text.replace(/\[\/releaseYear\]/ig, '</a>');
+
     text = text.replaceAll(']', ' class=standard_tile_link_black>');
     return text;
 }

--- a/public/themes/templates/1/main/games/games_reviews_add.html
+++ b/public/themes/templates/1/main/games/games_reviews_add.html
@@ -144,7 +144,13 @@
                                 <input type="button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'textfield')" class="primary_button" title="Recursive">
                                 <input type="button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield')" class="primary_button" title="Add links">
                                 <input type="button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield')" class="primary_button" title="Add email address">
-                                <textarea name="textfield" rows="15" class="primary_textarea" id="game_review_textfield" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);" placeholder="Review (required)" required></textarea>
+                                <input type="button" class="primary_button" name="addbbcode18" value="Game" onClick="bbstyle(18,'textfield')">
+                                <input type="button" class="primary_button" name="addbbcode20" value="Review" onClick="bbstyle(20,'textfield')">
+                                <input type="button" class="primary_button" name="addbbcode22" value="Interview" onClick="bbstyle(22,'textfield')">
+                                <input type="button" class="primary_button" name="addbbcode24" value="Article" onClick="bbstyle(24,'textfield')">
+                                <input type="button" class="primary_button" name="addbbcode26" value="Company" onClick="bbstyle(26,'textfield')">
+                                <input type="button" class="primary_button" name="addbbcode28" value="Release Year" onClick="bbstyle(28,'textfield')">
+                                        <textarea name="textfield" rows="15" class="primary_textarea" id="game_review_textfield" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);" placeholder="Review (required)" required></textarea>
                             </div>
                             <br>
                             <h6>Score :</h6>


### PR DESCRIPTION
Hi @stgraveyard ,

I implemented new BBCode tags in CPANEL in preparation for the Laravel go-live.
The page URLs will change, so we need to replace all BBCode tags like `[url=https://www.atarilegend.com/games/games_detail.php?game_id=165]` with new URLs like `[url=http://www.atarilegend.com/games/165]`.

I have prepared a DB script for that so we can convert most content when we go live. However once we are live the CPANEL will still be used to write News, Interviews, Articles etc. I though it would make sense to implement new tags:

- `[game=1234]Game[/game]`
- `[interview=1234]Interview[/interview]`
- `[article=1234]Article[/article]`
- `[review=1234]Review[/review]`
- `[company=1234]Company[/company]` (To search for all games of a company)
- `[releaseYear=1989]Year[/releaseYear]` (To search for all games of a year)

Both the current site and the Laravel one will replace the tags with the correct URLs (for example the old site will do `/games/games_detail.php?game_id=<GAMEID>` whereas Laravel will do `/games/<GAMEID>`. This way the CPANEL is compatible with both. I added corresponding buttons in the editors:

![1](https://user-images.githubusercontent.com/762512/99191002-2ecaee80-276a-11eb-9cef-73a83816b877.png)

I also fixed some bugs in the BBCode Javascript in CPANEL, it was not closing the tags correctly.

Let me know what you think, and could you let the team now to use these tags rather than make the `[url]` one to make links pointing to the site content?

Thanks,

Nico